### PR TITLE
Require NFC logging plugin

### DIFF
--- a/patterns/patterns-sailfish-device-configuration-xqau51.inc
+++ b/patterns/patterns-sailfish-device-configuration-xqau51.inc
@@ -13,9 +13,13 @@ Requires: droid-hal-version-xqau51
 
 Requires: patterns-sailfish-cellular-apps
 
+# NFC
+Requires: jolla-settings-system-nfc
+Requires: nfcd-dbuslog-plugin
+Requires: nfcd-mce-plugin
+
 Requires: sailfish-content-graphics-z%{icon_res}
 
-Requires: jolla-settings-system-nfc
 Requires: jolla-settings-system-flashlight
 
 Requires: geoclue-provider-mlsdb

--- a/patterns/patterns-sailfish-device-configuration-xqau52.inc
+++ b/patterns/patterns-sailfish-device-configuration-xqau52.inc
@@ -13,10 +13,14 @@ Requires: droid-hal-version-xqau52
 
 Requires: patterns-sailfish-cellular-apps
 
+# NFC
+Requires: jolla-settings-system-nfc
+Requires: nfcd-dbuslog-plugin
+Requires: nfcd-mce-plugin
+
 Requires: sailfish-content-graphics-z%{icon_res}
 
 Requires: jolla-settings-networking-multisim
-Requires: jolla-settings-system-nfc
 Requires: jolla-settings-system-flashlight
 
 Requires: geoclue-provider-mlsdb


### PR DESCRIPTION
It rarely makes sense to not include it if NFC is available.