### PR TITLE
gbinder: Use API level 29

### DIFF
--- a/sparse/etc/gbinder.conf
+++ b/sparse/etc/gbinder.conf
@@ -1,0 +1,2 @@
+[General]
+ApiLevel = 29


### PR DESCRIPTION
[gbinder] Use API level 29. JB#52325

Fixes registering dummy audioflinger.