### PR TITLE
configs: Override binding to netlink multicast group for hvdcp_opti.

### DIFF
--- a/sparse/usr/libexec/droid-hybris/system/etc/init/hvdcp_opti.rc
+++ b/sparse/usr/libexec/droid-hybris/system/etc/init/hvdcp_opti.rc
@@ -1,0 +1,7 @@
+service vendor.hvdcp_opti /odm/bin/hvdcp_opti
+    setenv UEVENT_NETLINK_GROUPS 0xFFFFFFFD
+    setenv LD_PRELOAD /usr/libexec/droid-hybris/system/lib64/libcutils.so
+    class main
+    user root
+    group system wakelock
+    override


### PR DESCRIPTION
Improves suspending of the device by ignoring events causing a lot of wakeups.

[configs] Override binding to netlink multicast group for hvdcp_opti. JB#54214