### PR TITLE
oom: fix low memory killer thresholds and score values

### DIFF
--- a/sparse/usr/lib/systemd/system/multi-user.target.wants/set-low-memory-killer-values.service
+++ b/sparse/usr/lib/systemd/system/multi-user.target.wants/set-low-memory-killer-values.service
@@ -1,0 +1,1 @@
+../set-low-memory-killer-values.service

--- a/sparse/usr/lib/systemd/system/set-low-memory-killer-values.service
+++ b/sparse/usr/lib/systemd/system/set-low-memory-killer-values.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Set LMK killer thresholds and score groups
+After=init-done.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "echo 92160,115200,138240,161280,206490 > /sys/module/lowmemorykiller/parameters/minfree;echo 0,58,147,529,1000 > /sys/module/lowmemorykiller/parameters/adj"


### PR DESCRIPTION
The default values from seine AOSP are:
```
cat /sys/module/lowmemorykiller/parameters/minfree
15360,19200,23040,26880,34415,43737
cat /sys/module/lowmemorykiller/parameters/adj
0,1,6,12
```
Set `minfree` to 6 times higher values, so lmkd actually starts working when
device is running out of available memory.
Also fix `adj` and match number of slots to `minfree`.