### PR TITLE
udev: Add missing path to firmware loader script.

### DIFF
--- a/sparse/usr/bin/droid/droid-load-firmware.sh
+++ b/sparse/usr/bin/droid/droid-load-firmware.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+FIRMWARE_FOLDERS="/system/etc/firmware/ /odm/firmware/ /vendor/firmware/ /firmware/image/ /vendor/firmware_mnt/image/"
+
+log() {
+    logger -p daemon.info -t firmware "$@"
+}
+
+log "Attempting to load firmware $FIRMWARE for $DEVPATH"
+
+if [ -e /sys$DEVPATH/loading ]; then
+    for folder in $FIRMWARE_FOLDERS; do
+        if [ -e "$folder/$FIRMWARE" ]; then
+            log "Loading firmware $folder/$FIRMWARE"
+
+            echo 1 > /sys$DEVPATH/loading
+            cat "$folder/$FIRMWARE" > /sys$DEVPATH/data
+            echo 0 > /sys$DEVPATH/loading
+
+            log "Loaded firmware $FIRMWARE"
+            exit 0
+        fi
+    done
+
+    log "Failed to find firmware $FIRMWARE for $DEVPATH"
+    echo "\-1" > /sys$DEVPATH/loading
+    exit 1
+else
+    log "Failed to find /sys$DEVPATH/loading, could not load $FIRMWARE."
+    exit 1
+fi
+


### PR DESCRIPTION
[udev] Add missing path to firmware loader script. JB#56087

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>