### PR TITLE
configs: handle android hwc start/stop via mce

### DIFF
--- a/delete_file_xqau51.list
+++ b/delete_file_xqau51.list
@@ -2,3 +2,7 @@
 /etc/ofono/ril_subscription.d/dual-sim.conf
 /usr/share/csd/settings.d/20-hw-settings-dual-sim.ini
 /usr/share/ssu/board-mappings.d/10-xqau52.ini
+/usr/lib/systemd/system/sailfish-unlock-agent.service.d/50-vendor.hwcomposer-2-3.conf
+/usr/lib/systemd/system/sailfish-upgrade-ui.service.d/50-vendor.hwcomposer-2-3.conf
+/usr/lib/systemd/user/jolla-startupwizard-pre-user-session.service.d/50-vendor.hwcomposer-2-3.conf
+/usr/lib/systemd/user/lipstick.service.d/50-vendor.hwcomposer-2-3.conf

--- a/delete_file_xqau52.list
+++ b/delete_file_xqau52.list
@@ -1,1 +1,5 @@
 /usr/share/ssu/board-mappings.d/10-xqau51.ini
+/usr/lib/systemd/system/sailfish-unlock-agent.service.d/50-vendor.hwcomposer-2-3.conf
+/usr/lib/systemd/system/sailfish-upgrade-ui.service.d/50-vendor.hwcomposer-2-3.conf
+/usr/lib/systemd/user/jolla-startupwizard-pre-user-session.service.d/50-vendor.hwcomposer-2-3.conf
+/usr/lib/systemd/user/lipstick.service.d/50-vendor.hwcomposer-2-3.conf

--- a/sparse/etc/mce/60-compositor-seine.ini
+++ b/sparse/etc/mce/60-compositor-seine.ini
@@ -1,0 +1,4 @@
+[Compositor]
+StopHwCompositor=/system/bin/stop vendor.hwcomposer-2-3
+StartHwCompositor=/system/bin/start vendor.hwcomposer-2-3
+RestartHwCompositor=/usr/bin/setprop ctl.restart vendor.hwcomposer-2-3

--- a/sparse/usr/lib/systemd/system/autologin@.service.d/50-vendor-hwcomposer-2-3.conf
+++ b/sparse/usr/lib/systemd/system/autologin@.service.d/50-vendor-hwcomposer-2-3.conf
@@ -1,4 +1,0 @@
-[Service]
-# Restart hwcomposer to allow user switching to work
-ExecStopPost=+-/system/bin/stop vendor.hwcomposer-2-3
-ExecStopPost=+-/system/bin/start vendor.hwcomposer-2-3

--- a/sparse/usr/lib/systemd/system/yamuisplash.service.d/50-vendor-hwcomposer-2-3.conf
+++ b/sparse/usr/lib/systemd/system/yamuisplash.service.d/50-vendor-hwcomposer-2-3.conf
@@ -1,6 +1,0 @@
-[Service]
-ExecStartPre=-/system/bin/stop vendor.hwcomposer-2-3
-
-# stop first in case something else managed to start it
-ExecStopPost=-/system/bin/stop vendor.hwcomposer-2-3
-ExecStopPost=-/system/bin/start vendor.hwcomposer-2-3


### PR DESCRIPTION
Add configuration file for instructing mce how to start/stop hwc.

Adjust systemd service drop-ins to utilize dummy_compositor in such way that makes android hwc available for Qt based UIs under control of mce.

[configs] Handle android hwc start/stop via mce. JB#59917

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>