### PR TITLE
networking: Enable bluetooth tethering on seine

### DIFF
--- a/sparse/usr/share/csd/settings.d/10-hw-settings.ini
+++ b/sparse/usr/share/csd/settings.d/10-hw-settings.ini
@@ -6,6 +6,7 @@ BackCameraFlash=1
 Backlight=1
 Battery=1
 Bluetooth=1
+BluetoothTethering=1
 CellularData=1
 CellularVoice=1
 ECompass=1


### PR DESCRIPTION
Declare BluetoothTethering as supported in csd config for the X10ii.

[networking] Enable bluetooth tethering on seine. JB#60489