### PR TITLE
patterns: Require sailfish-fpd

### DIFF
--- a/patterns/patterns-sailfish-device-adaptation-pdx201.inc
+++ b/patterns/patterns-sailfish-device-adaptation-pdx201.inc
@@ -62,6 +62,7 @@ Requires: rfkill
 
 # enable fingerprint reader
 Requires: sailfish-devicelock-fpd
+Requires: sailfish-fpd
 
 # Enable home encryption
 Requires: sailfish-device-encryption


### PR DESCRIPTION
As sailfish-devicelock-fpd no longer explicitly requires sailfish-fpd, it needs to be pulled in via patterns.

[patterns] Require sailfish-fpd. JB#62474